### PR TITLE
Workaround util fixed upstream

### DIFF
--- a/.github/workflows/compress-images-cron.yml
+++ b/.github/workflows/compress-images-cron.yml
@@ -26,3 +26,5 @@ jobs:
           branch-suffix: timestamp
           commit-message: Compressed Images
           body: ${{ steps.calibre.outputs.markdown }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'

--- a/.github/workflows/misspell-fixer-action.yml
+++ b/.github/workflows/misspell-fixer-action.yml
@@ -12,3 +12,5 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: 'Fixes by misspell-fixer'
         title: 'Typos fix by misspell-fixer'
+      env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'


### PR DESCRIPTION
```
Error: Unable to process command '::set-env name=pythonLocation,::/opt/hostedtoolcache/Python/3.9.5/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands
```