### PR TITLE
fix: add Gherkin syntax highlighting support

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -4,11 +4,11 @@
   <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.2.0/build/styles/night-owl.min.css">
   <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.2.0/build/highlight.min.js" crossorigin="anonymous"></script>
   <script type="text/javascript" src="//cdn.jsdelivr.net/gh/highlightjs/highlightjs-terraform/terraform.min.js"></script>
+  <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.2.0/build/languages/gherkin.min.js"></script>
   <script type="text/javascript">
     hljs.registerLanguage('terraform', window.hljsDefineTerraform);
     hljs.initHighlightingOnLoad();
   </script>
-<script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.2.0/build/highlight.min.js"></script>
 {{ else if eq .Site.Params.syntaxHighlighter "prism.js" }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/prism.min.js" integrity="sha512-UOoJElONeUNzQbbKQbjldDf9MwOHqxNz49NNJJ1d90yp+X9edsHyJoAs6O4K19CZGaIdjI5ohK+O2y5lBTW6uQ==" crossorigin="anonymous"></script>
 {{ end }}


### PR DESCRIPTION
## Summary
- Added Gherkin language module to highlight.js configuration
- Fixes console error: "Could not find the language 'gherkin'"
- Removed duplicate highlight.min.js script tag

## Details
The theme was loading highlight.js with Terraform support but missing Gherkin/Cucumber language support. When rendering code blocks with `language-gherkin` class, highlight.js would throw an error and fall back to no highlighting.

## Test Plan
- [x] Built site with `hugo` - no errors
- [x] Verified Gherkin script loads in generated HTML
- [x] Confirmed syntax highlighting renders correctly for Gherkin code blocks in the "Testing CLI apps with Aruba" post

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting support for Gherkin language.

* **Bug Fixes**
  * Removed duplicate script loading to optimize performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->