### PR TITLE
Switch from go3up to s5cmd for S3 deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,17 +56,6 @@ jobs:
       - name: Build site
         run: hugo --destination "$SOURCE_DIR"
 
-      # go3up configuration files (.go3up.json, .go3up.txt) are in repository root
-      # and will be automatically discovered by go3up
-
-      - name: Restore go3up cache
-        uses: actions/cache@v5
-        with:
-          path: .go3up.txt
-          key: go3up-cache-${{ github.sha }}
-          restore-keys: |
-            go3up-cache-
-
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -76,25 +65,21 @@ jobs:
         # This action uses OIDC to assume the IAM role and exports temporary credentials
         # as environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
 
-      - name: Upload to S3 using go3up with OIDC credentials
+      - name: Install s5cmd
         run: |
-          docker run --rm \
-            -v $(pwd):/workspace \
-            -w /workspace \
-            -e AWS_ACCESS_KEY_ID \
-            -e AWS_SECRET_ACCESS_KEY \
-            -e AWS_SESSION_TOKEN \
-            petems/go3up \
-            /usr/local/bin/go3up -source="$SOURCE_DIR" -region="$S3_REGION" -bucket="$S3_BUCKET" --verbose
-        # go3up reads the temporary OIDC credentials from environment variables
-        # AWS_SESSION_TOKEN proves these are temporary credentials, not static keys
+          curl -L https://github.com/peak/s5cmd/releases/latest/download/s5cmd_$(uname -s)_$(uname -m | sed 's/x86_64/amd64/').tar.gz | tar xz
+          sudo mv s5cmd /usr/local/bin/
+          s5cmd version
 
-      - name: Save go3up cache
-        uses: actions/cache/save@v5
-        if: always()
-        with:
-          path: .go3up.txt
-          key: go3up-cache-${{ github.sha }}
+      - name: Sync to S3 using s5cmd with OIDC credentials
+        run: |
+          s5cmd --log=info sync \
+            --delete \
+            "$SOURCE_DIR/*" \
+            "s3://$S3_BUCKET/"
+        # s5cmd uses AWS credentials from environment variables (set by configure-aws-credentials action)
+        # --delete removes files from S3 that don't exist in source
+        # --log=info provides visibility into what's being uploaded
 
       - name: Deployment complete
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The project includes several utility targets in the Makefile:
 
 ## GitHub Actions Commands
 
-The site deploys automatically via GitHub Actions when code is pushed to `master`.
+The site deploys automatically via GitHub Actions when code is pushed to `master`. The deployment uses `s5cmd` for fast, efficient S3 synchronization.
 
 ### Viewing Deployments
 
@@ -125,8 +125,8 @@ If switching to ugly URLs, modify both `config.toml` and `terraform/s3-website/m
 **GitHub Actions** (Primary):
 - Workflow defined in `.github/workflows/deploy.yml`
 - Triggers on push to `master` branch
-- Uses Hugo v0.54.0 for building
-- Deploys to S3 using `go3up` with MD5 caching
+- Uses Hugo for building
+- Deploys to S3 using `s5cmd` for fast synchronization
 - Authentication via OIDC (no static AWS keys)
 - View deployments: https://github.com/petems/petersouter.xyz/actions
 


### PR DESCRIPTION
## Summary
- Replace Docker-based go3up sync tool with native s5cmd for S3 deployments
- Remove cache management steps (no longer needed with s5cmd)
- Update documentation in CLAUDE.md

## Benefits
- **Faster deployments**: Native binary with parallel transfers, no Docker overhead
- **Simpler workflow**: No cache file management required
- **Better cleanup**: `--delete` flag ensures S3 stays in sync with source
- **Improved visibility**: `--log=info` provides clear deployment logging

## Changes
- Modified `.github/workflows/deploy.yml` to install and use s5cmd
- Updated `CLAUDE.md` documentation to reflect new deployment method
- Removed go3up cache restore/save steps

## Test plan
- [x] Workflow syntax is valid
- [ ] Verify deployment succeeds on merge to master
- [ ] Confirm S3 sync works correctly with OIDC credentials
- [ ] Check that `--delete` flag properly removes old files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure with new S3 synchronization tooling, enabling more efficient releases with enhanced file management capabilities and improved logging for operational visibility.
  * Refreshed deployment documentation and build configuration references to align with the updated workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->