### PR TITLE
chore: update Hugo from v0.152.2 to v0.155.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
 ARG VARIANT=hugo
 # VERSION can be either 'latest' or a specific version number
-ARG VERSION=0.54.0
+ARG VERSION=0.155.3
 
 # Download Hugo
 RUN case ${VERSION} in \

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,7 +32,7 @@ This directory contains GitHub Actions workflows for automated testing and deplo
 
 2. **Build and Deploy Job** (runs after test job passes):
    - Checks out code with submodules
-   - Sets up Hugo 0.152.2
+   - Sets up Hugo 0.155.3
    - Builds the static site
    - Configures AWS credentials via OIDC
    - Uploads to S3 using go3up

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.152.2'
+          hugo-version: '0.155.3'
           extended: true
 
       - name: Build site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ If switching to ugly URLs, modify both `config.toml` and `terraform/s3-website/m
 **GitHub Actions** (Primary):
 - Workflow defined in `.github/workflows/deploy.yml`
 - Triggers on push to `master` branch
-- Uses Hugo v0.54.0 for building
+- Uses Hugo v0.155.3 for building
 - Deploys to S3 using `go3up` with MD5 caching
 - Authentication via OIDC (no static AWS keys)
 - View deployments: https://github.com/petems/petersouter.xyz/actions

--- a/static/humans.txt
+++ b/static/humans.txt
@@ -12,4 +12,4 @@ Standards: HTML5, CSS3
 Components: Hugo, Tranquilpeak Theme
 Hosting: AWS S3, CloudFront CDN
 Deployment: GitHub Actions
-Tools: go3up, Hugo v0.54.0
+Tools: go3up, Hugo v0.155.3

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "HUGO_VERSION": "0.152.2"
+      "HUGO_VERSION": "0.155.3"
     }
   },
   "buildCommand": "./build.sh"


### PR DESCRIPTION
## Summary
Updates Hugo to the latest stable version (v0.155.3, released February 8, 2026) across all configuration files and documentation.

## Changes
- **GitHub Actions workflow** (`.github/workflows/deploy.yml`): v0.152.2 → v0.155.3
- **Vercel config** (`vercel.json`): v0.152.2 → v0.155.3
- **Dev container** (`.devcontainer/Dockerfile`): v0.54.0 → v0.155.3
- **Documentation** (`CLAUDE.md`, `.github/workflows/README.md`): Updated version references
- **Site metadata** (`static/humans.txt`): Updated version reference

## Breaking Changes Analysis
The main breaking change in v0.155.0 affects alias path handling (paths beginning with `/` are now site-relative instead of server-relative), but this only impacts multilingual sites crossing language boundaries. 

**Impact**: ✅ None - This is a single-language site (en-uk).

## Test Plan
- [ ] Vercel preview deployment builds successfully
- [ ] GitHub Actions workflow builds successfully
- [ ] Site renders correctly in preview
- [ ] All links and aliases work as expected

## References
- [Hugo v0.155.3 Release](https://github.com/gohugoio/hugo/releases/tag/v0.155.3)
- [Hugo v0.155.2 Release Notes](https://discourse.gohugo.io/t/hugo-v0-155-2-released/56663)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Hugo to v0.155.3 across build and deployment configurations (development container, CI workflows, and hosting/build settings).
* **Documentation**
  * Updated project documentation and metadata to reflect the new Hugo version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->