### PR TITLE
feat: add Hugo shortcode for embedding Bluesky posts

### DIFF
--- a/layouts/shortcodes/bluesky.html
+++ b/layouts/shortcodes/bluesky.html
@@ -1,8 +1,19 @@
-{{- $link := .Get "link"  -}}
-{{- $query := querify "url" $link -}}
-{{- $request := printf "https://embed.bsky.app/oembed?%s" $query -}}
-
-{{- $jsonOembed := resources.GetRemote $request -}}
-{{- $jsonOembed = $jsonOembed | transform.Unmarshal -}}
-{{- $jsonOHTML := $jsonOembed.html -}}
-{{- $jsonOHTML | safeHTML -}}
+{{- $link := .Get "link" -}}
+{{- if $link -}}
+  {{- $query := querify "url" $link "format" "json" -}}
+  {{- $request := printf "https://embed.bsky.app/oembed?%s" $query -}}
+  {{- with try (resources.GetRemote $request) -}}
+    {{- with .Err -}}
+      {{- warnf "bluesky shortcode: failed to fetch oEmbed for %q: %s" $link . -}}
+    {{- else -}}
+      {{- with .Value -}}
+        {{- $jsonOembed := unmarshal .Content -}}
+        {{- with $jsonOembed.html -}}
+          {{- . | safeHTML -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- warnf "bluesky shortcode: missing required \"link\" parameter" -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- Adds a new Hugo shortcode for embedding Bluesky posts using their oEmbed API
- Enables simple Bluesky post embeds in blog content with minimal markup

## Implementation
- Created `layouts/shortcodes/bluesky.html` with oEmbed integration
- Uses Hugo's `resources.GetRemote` to fetch embed data from `embed.bsky.app`
- Renders embedded posts with Bluesky's official embed HTML/JavaScript

## Usage
```markdown
{{< bluesky link="https://bsky.app/profile/username/post/postid" >}}
```

## Notes
- Requires JavaScript for full rendering (falls back to text-only without JS)
- No additional configuration or dependencies needed
- Based on implementation from https://www.brycewray.com/posts/2024/11/simple-hugo-shortcode-embedding-bluesky-posts/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced support for embedding Bluesky posts directly in your content. A new shortcode enables you to include live Bluesky posts by simply providing a post link. The posts are automatically fetched and displayed on your pages, allowing for seamless integration of Bluesky content throughout your site without requiring manual formatting or additional tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->