### PR TITLE
feat(skills): add AI writing tells checklist to all blog skills

### DIFF
--- a/.claude/context/ai-writing-tells.md
+++ b/.claude/context/ai-writing-tells.md
@@ -10,9 +10,9 @@ Words that spiked in frequency after 2023, corroborated by peer-reviewed studies
 
 > additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), multifaceted, nuanced, pivotal, realm, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
 
-One or two in a full email is fine. A cluster of 3+ in a section means the LLM was on autopilot.
+One or two in a full post is fine. A cluster of 3+ in a section means the LLM was on autopilot.
 
-**Email-specific note:** Sales engineering emails are particularly susceptible to "leverage", "robust", "seamless", "cutting-edge", and "best-in-class". These are vendor cliches even without AI involvement, but LLMs reach for them reflexively.
+**Blog-specific note:** Tech blog posts are particularly susceptible to "leverage", "robust", "seamless", "cutting-edge", and "best-in-class". These are vendor cliches even without AI involvement, but LLMs reach for them reflexively.
 
 ## Inflated significance
 
@@ -28,7 +28,7 @@ LLMs inflate importance with a small repertoire of phrases. Scan for:
 - "deeply rooted"
 - "enduring/lasting legacy"
 
-**The fix:** Say what actually happened. Specific facts beat vague significance. In customer emails, concrete capabilities and measurable outcomes are always more persuasive than inflated language.
+**The fix:** Say what actually happened. Specific facts beat vague significance. In blog posts, concrete details and real experiences are always more compelling than inflated language.
 
 ## Superficial -ing analysis
 
@@ -41,7 +41,7 @@ LLMs tack present participle phrases onto sentences as fake depth:
 - "...contributing to the ecosystem"
 - "...fostering a sense of community"
 
-**The fix:** If the -ing clause adds no information the reader didn't already have, cut it. Customer emails should be concise - trailing participle phrases pad length without adding value.
+**The fix:** If the -ing clause adds no information the reader didn't already have, cut it. Blog posts should be concise - trailing participle phrases pad length without adding value.
 
 ## Promotional language
 
@@ -49,7 +49,7 @@ Words that read like a travel brochure or sales deck:
 
 > breathtaking, stunning, nestled, in the heart of, boasts a, vibrant, rich (figurative), profound, groundbreaking (figurative), renowned, showcasing, exemplifies, commitment to, natural beauty, rich cultural tapestry/heritage
 
-Good SE emails are enthusiastic but specific. "APM reduced their P99 latency from 800ms to 120ms" beats "our groundbreaking, industry-leading APM solution delivers a profound improvement in application performance."
+Good blog writing is enthusiastic but specific. "I cut the deploy time from 8 minutes to 45 seconds" beats "this groundbreaking approach delivers a profound improvement in deployment performance."
 
 ## Vague authority
 
@@ -61,7 +61,7 @@ LLMs attribute claims to phantom experts:
 - "Some critics contend..."
 - "Several publications have noted..."
 
-**The fix:** Name the source or drop the attribution. Link to the actual documentation, blog post, or case study. Customers trust specificity over anonymous authority.
+**The fix:** Name the source or drop the attribution. Link to the actual documentation, blog post, or case study. Readers trust specificity over anonymous authority.
 
 ## Formulaic transitions
 
@@ -69,7 +69,7 @@ These transitions read like a five-paragraph essay:
 
 > moreover, furthermore, in addition, on the other hand, in contrast, it's important to note, it is worth mentioning, no discussion would be complete without
 
-Professional email uses direct transitions or none at all. A line break between topics is often better than a forced connector.
+Good blog writing uses direct transitions or none at all. A line break between topics is often better than a forced connector.
 
 ## Negative parallelism overuse
 
@@ -79,7 +79,7 @@ The "not X, it's Y" construction:
 - "Not only... but also..."
 - "It isn't X - it's Y"
 
-**Nuance:** This pattern works sparingly for genuine emphasis. The tell is when every other paragraph uses it, or when it creates false profundity from obvious contrasts. In customer emails, one instance per message is the maximum before it becomes a tic.
+**Nuance:** This pattern works sparingly for genuine emphasis. The tell is when every other paragraph uses it, or when it creates false profundity from obvious contrasts. One instance per post section is the maximum before it becomes a tic.
 
 ## Rule of three
 
@@ -90,7 +90,7 @@ LLMs default to grouping things in threes:
 
 When every list has exactly three items, it's suspicious. Vary the count. Two items is fine. Four is fine. One is fine.
 
-**Email-specific note:** Feature lists in customer emails should contain exactly as many items as are relevant - no padding to hit three, no trimming to avoid four.
+**Blog-specific note:** Lists in blog posts should contain exactly as many items as are relevant - no padding to hit three, no trimming to avoid four.
 
 ## Copula avoidance
 
@@ -103,7 +103,7 @@ LLMs replace "is" with fancier verbs:
 - "boasts" instead of "has"
 - "features" instead of "has"
 
-Sometimes the fancy verb is right. Usually "is" is better. In customer emails, directness builds trust.
+Sometimes the fancy verb is right. Usually "is" is better. In blog writing, directness builds trust.
 
 ## Elegant variation
 
@@ -111,7 +111,7 @@ LLMs use increasingly elaborate synonyms to avoid repeating a word:
 
 > the tool - the solution - the platform - the offering - the ecosystem
 
-If you're talking about Datadog, just say Datadog again. If you're talking about APM, say APM. Readers don't mind repetition of concrete nouns. They notice when you cycle through thesaurus entries.
+If you're talking about Hugo, just say Hugo again. If you're talking about Terraform, say Terraform. Readers don't mind repetition of concrete nouns. They notice when you cycle through thesaurus entries.
 
 ## Em dash overuse
 
@@ -124,7 +124,7 @@ LLMs use em dashes at 2-3x the rate of human writers. They substitute them for c
 - **Bullet + bold header + colon**: the "**Term:** Description of term" pattern in every list
 - **Emoji decoration**: emoji before every section heading or bullet point
 
-**Email-specific note:** Customer emails should use formatting sparingly. A wall of bold text and bullet points can feel like a product datasheet rather than a personal response. Use formatting to aid scanning, not to decorate.
+**Blog-specific note:** Blog posts should use formatting sparingly. A wall of bold text and bullet points can feel like a product datasheet rather than a personal post. Use formatting to aid scanning, not to decorate.
 
 ## Challenges-and-future formula
 
@@ -136,4 +136,4 @@ The rigid "Despite its success, X faces challenges... Despite these challenges, 
 2. Read through once scanning for vocabulary clusters
 3. Read through again checking structural patterns (parallelism density, list uniformity, transition formality)
 4. For each hit: Is this a deliberate rhetorical choice, or did the LLM default to it? If you can't articulate why the fancy version is better, use the plain one
-5. When in doubt, read it aloud. If it sounds like a press release, rewrite it. If it sounds like something you'd actually say to a customer face-to-face, keep it
+5. When in doubt, read it aloud. If it sounds like a press release, rewrite it. If it sounds like something you'd actually say in a conversation, keep it

--- a/.claude/context/ai-writing-tells.md
+++ b/.claude/context/ai-writing-tells.md
@@ -1,0 +1,139 @@
+# AI Writing Tells - Self-Review Checklist
+
+Adapted from [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), which catalogs patterns statistically overrepresented in LLM output. Use this as a final pass to catch robotic phrasing that slipped through into blog drafts.
+
+This checklist is **descriptive, not prescriptive**. A few of these patterns appear naturally in good human writing. The signal is density - one "pivotal" is fine; five AI vocabulary words in two paragraphs is a rewrite.
+
+## Overused AI vocabulary
+
+Words that spiked in frequency after 2023, corroborated by peer-reviewed studies. Scan for clusters of these:
+
+> additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), multifaceted, nuanced, pivotal, realm, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
+
+One or two in a full email is fine. A cluster of 3+ in a section means the LLM was on autopilot.
+
+**Email-specific note:** Sales engineering emails are particularly susceptible to "leverage", "robust", "seamless", "cutting-edge", and "best-in-class". These are vendor cliches even without AI involvement, but LLMs reach for them reflexively.
+
+## Inflated significance
+
+LLMs inflate importance with a small repertoire of phrases. Scan for:
+
+- "stands as a testament"
+- "plays a vital/significant/crucial/pivotal role"
+- "underscores its importance"
+- "watershed moment" / "key turning point"
+- "indelible mark"
+- "setting the stage for"
+- "evolving landscape"
+- "deeply rooted"
+- "enduring/lasting legacy"
+
+**The fix:** Say what actually happened. Specific facts beat vague significance. In customer emails, concrete capabilities and measurable outcomes are always more persuasive than inflated language.
+
+## Superficial -ing analysis
+
+LLMs tack present participle phrases onto sentences as fake depth:
+
+- "...ensuring a seamless experience"
+- "...highlighting its importance"
+- "...emphasizing the need for"
+- "...reflecting broader trends"
+- "...contributing to the ecosystem"
+- "...fostering a sense of community"
+
+**The fix:** If the -ing clause adds no information the reader didn't already have, cut it. Customer emails should be concise - trailing participle phrases pad length without adding value.
+
+## Promotional language
+
+Words that read like a travel brochure or sales deck:
+
+> breathtaking, stunning, nestled, in the heart of, boasts a, vibrant, rich (figurative), profound, groundbreaking (figurative), renowned, showcasing, exemplifies, commitment to, natural beauty, rich cultural tapestry/heritage
+
+Good SE emails are enthusiastic but specific. "APM reduced their P99 latency from 800ms to 120ms" beats "our groundbreaking, industry-leading APM solution delivers a profound improvement in application performance."
+
+## Vague authority
+
+LLMs attribute claims to phantom experts:
+
+- "Industry reports suggest..."
+- "Observers have cited..."
+- "Experts argue..."
+- "Some critics contend..."
+- "Several publications have noted..."
+
+**The fix:** Name the source or drop the attribution. Link to the actual documentation, blog post, or case study. Customers trust specificity over anonymous authority.
+
+## Formulaic transitions
+
+These transitions read like a five-paragraph essay:
+
+> moreover, furthermore, in addition, on the other hand, in contrast, it's important to note, it is worth mentioning, no discussion would be complete without
+
+Professional email uses direct transitions or none at all. A line break between topics is often better than a forced connector.
+
+## Negative parallelism overuse
+
+The "not X, it's Y" construction:
+
+- "It's not just about X, it's about Y"
+- "Not only... but also..."
+- "It isn't X - it's Y"
+
+**Nuance:** This pattern works sparingly for genuine emphasis. The tell is when every other paragraph uses it, or when it creates false profundity from obvious contrasts. In customer emails, one instance per message is the maximum before it becomes a tic.
+
+## Rule of three
+
+LLMs default to grouping things in threes:
+
+- "convenient, efficient, and innovative"
+- "keynote sessions, panel discussions, and networking opportunities"
+
+When every list has exactly three items, it's suspicious. Vary the count. Two items is fine. Four is fine. One is fine.
+
+**Email-specific note:** Feature lists in customer emails should contain exactly as many items as are relevant - no padding to hit three, no trimming to avoid four.
+
+## Copula avoidance
+
+LLMs replace "is" with fancier verbs:
+
+- "serves as" instead of "is"
+- "stands as" instead of "is"
+- "represents" instead of "is"
+- "marks" instead of "is"
+- "boasts" instead of "has"
+- "features" instead of "has"
+
+Sometimes the fancy verb is right. Usually "is" is better. In customer emails, directness builds trust.
+
+## Elegant variation
+
+LLMs use increasingly elaborate synonyms to avoid repeating a word:
+
+> the tool - the solution - the platform - the offering - the ecosystem
+
+If you're talking about Datadog, just say Datadog again. If you're talking about APM, say APM. Readers don't mind repetition of concrete nouns. They notice when you cycle through thesaurus entries.
+
+## Em dash overuse
+
+LLMs use em dashes at 2-3x the rate of human writers. They substitute them for commas, parentheses, and colons in a formulaic, "punched up" style. When every other sentence has one, or when a comma would be more natural, it's a tell.
+
+## Formatting tells
+
+- **Excessive boldface**: bolding every key term mechanically, "key takeaways" style
+- **Title case in every heading**: use sentence case instead
+- **Bullet + bold header + colon**: the "**Term:** Description of term" pattern in every list
+- **Emoji decoration**: emoji before every section heading or bullet point
+
+**Email-specific note:** Customer emails should use formatting sparingly. A wall of bold text and bullet points can feel like a product datasheet rather than a personal response. Use formatting to aid scanning, not to decorate.
+
+## Challenges-and-future formula
+
+The rigid "Despite its success, X faces challenges... Despite these challenges, X continues to thrive" sandwich. If you catch yourself writing "despite" twice in a paragraph, restructure.
+
+## How to use this checklist
+
+1. Finish the draft first - don't self-censor while writing
+2. Read through once scanning for vocabulary clusters
+3. Read through again checking structural patterns (parallelism density, list uniformity, transition formality)
+4. For each hit: Is this a deliberate rhetorical choice, or did the LLM default to it? If you can't articulate why the fancy version is better, use the plain one
+5. When in doubt, read it aloud. If it sounds like a press release, rewrite it. If it sounds like something you'd actually say to a customer face-to-face, keep it

--- a/.claude/skills/new-generated-blog-post/SKILL.md
+++ b/.claude/skills/new-generated-blog-post/SKILL.md
@@ -194,10 +194,25 @@ GitHub Actions will automatically optimise images on commit — no manual compre
 - [ ] `categories` uses established values only
 - [ ] Image paths point to real files or are `""`
 
+#### AI Writing Tells
+
+Before finalising, review the draft against `.claude/context/ai-writing-tells.md`. Scan for and eliminate:
+
+- Clusters of AI-overrepresented vocabulary ("delve", "crucial", "multifaceted", "landscape", "tapestry", "underscore", "foster")
+- Inflated significance phrases ("stands as a testament", "plays a pivotal role")
+- Trailing -ing phrases that add no information ("...ensuring a seamless experience")
+- Formulaic transitions ("moreover", "furthermore", "it's important to note")
+- Every list having exactly three items — vary the count
+- Copula avoidance ("serves as" when "is" is more direct)
+- Elegant variation (cycling through synonyms instead of repeating the concrete noun)
+
+The signal is density — one instance is fine; a cluster in a section means rewrite that section in Peter's natural voice.
+
 #### Content Quality
 
 - [ ] `<!--more-->` is present after opening paragraph
 - [ ] British English spelling used throughout
+- [ ] No AI writing tell clusters (checked against `.claude/context/ai-writing-tells.md`)
 - [ ] Internal links to existing posts where relevant
 - [ ] External links to authoritative sources
 - [ ] No broken markdown links or image references

--- a/.claude/skills/new-guided-blog-post/SKILL.md
+++ b/.claude/skills/new-guided-blog-post/SKILL.md
@@ -97,7 +97,13 @@ Once the full draft is complete:
    - No corporate-speak or marketing language
    - Clear, scannable structure with headers and lists
 
-3. **Verify content quality**:
+3. **Scan for AI writing tells** (see `.claude/context/ai-writing-tells.md`):
+   - Check for clusters of AI-overrepresented vocabulary ("delve", "crucial", "multifaceted", "landscape", "tapestry", "underscore", "foster")
+   - Remove inflated significance phrases, trailing -ing filler, and formulaic transitions
+   - Vary list lengths (not always three items), prefer "is" over "serves as"/"stands as"
+   - The signal is density — one instance is fine; a cluster means rewrite in Peter's voice
+
+4. **Verify content quality**:
    - Technical claims are accurate
    - Code examples work and have context
    - Personal voice maintained throughout

--- a/.claude/skills/non-tech-blog-editor/SKILL.md
+++ b/.claude/skills/non-tech-blog-editor/SKILL.md
@@ -82,6 +82,7 @@ When flagging AI tells, quote the specific passage and suggest a rewrite that so
 Review and apply Peter's writing voice from `.claude/context/writing-style.md`:
 
 ### Voice Characteristics
+
 - **First-person, conversational, personal**: Use "I've been", "I was tinkering", "I thought"
 - **Informal and friendly**: Use contractions liberally, parenthetical asides, em-dashes
 - **Self-deprecating humor**: Comfortable admitting gaps and mistakes
@@ -89,11 +90,13 @@ Review and apply Peter's writing voice from `.claude/context/writing-style.md`:
 - **Honest and candid**: Not afraid to discuss struggles or incomplete projects
 
 ### Structural Patterns
+
 - **Opening hooks**: Start with a personal experience, problem you hit, or observation
 - **Clear section organization**: H2/H3 headers, sometimes playful ("Enter Boxen", "Turtles all the way down")
 - **Closing style**: Practical takeaway, honest reflection, or forward-looking thought
 
 ### What to Avoid
+
 - Overusing emojis
 - No corporate-speak or marketing language
 - No unnecessary preamble ("In conclusion...")

--- a/.claude/skills/non-tech-blog-editor/SKILL.md
+++ b/.claude/skills/non-tech-blog-editor/SKILL.md
@@ -54,12 +54,53 @@ You are a meticulous editor specializing in personal essays, trip reports, opini
 - **Asides**: Are they adding personality or distracting from the main thread?
 - **SEO**: Is the description compelling? Would the title work in search results and social sharing?
 
+### AI Writing Tells
+
+Review the post against the checklist in `.claude/context/ai-writing-tells.md`. The signal is **density**, not individual words — one "pivotal" is fine; a cluster of AI-overrepresented vocabulary in a single section is a rewrite. Scan for:
+
+- **Vocabulary clusters**: Words like "delve", "crucial", "multifaceted", "landscape", "tapestry", "underscore", "foster" — flag when 3+ appear in close proximity
+- **Inflated significance**: "stands as a testament", "plays a pivotal role", "indelible mark" — say what actually happened instead
+- **Trailing -ing phrases**: "...ensuring a seamless experience", "...highlighting its importance" — cut if they add no new information
+- **Formulaic transitions**: "moreover", "furthermore", "it's important to note" — Peter's natural transitions are more casual ("So with that in mind...", "For my next trick...")
+- **Negative parallelism overuse**: "It's not just about X, it's about Y" repeated across paragraphs
+- **Rule of three**: Every list having exactly three items is suspicious — vary the count
+- **Copula avoidance**: "serves as" / "stands as" when "is" would be more direct
+- **Elegant variation**: Cycling through synonyms ("the tool — the solution — the platform — the offering") instead of just repeating the concrete noun
+- **Formatting tells**: Excessive boldface, "**Term:** Description" in every bullet, emoji decoration
+
+When flagging AI tells, quote the specific passage and suggest a rewrite that sounds like Peter's natural voice. The goal is authenticity, not paranoia — some of these patterns appear in good human writing too.
+
 ### Engagement
 
 - **Reader value**: Is it clear what the reader gains — entertainment, insight, a useful recommendation, a shared experience?
 - **Pacing**: Does the post maintain interest or drag in places? Are any sections disproportionately long?
 - **Relatability**: Will readers connect with the experiences or opinions described?
 - **Voice & personality**: Does the author's personality come through? Personal posts should feel personal
+
+## Writing Style Reference
+
+Review and apply Peter's writing voice from `.claude/context/writing-style.md`:
+
+### Voice Characteristics
+- **First-person, conversational, personal**: Use "I've been", "I was tinkering", "I thought"
+- **Informal and friendly**: Use contractions liberally, parenthetical asides, em-dashes
+- **Self-deprecating humor**: Comfortable admitting gaps and mistakes
+- **Enthusiastic about discovery**: Genuine excitement about expressing themselves and teaching new topics
+- **Honest and candid**: Not afraid to discuss struggles or incomplete projects
+
+### Structural Patterns
+- **Opening hooks**: Start with a personal experience, problem you hit, or observation
+- **Clear section organization**: H2/H3 headers, sometimes playful ("Enter Boxen", "Turtles all the way down")
+- **Closing style**: Practical takeaway, honest reflection, or forward-looking thought
+
+### What to Avoid
+- Overusing emojis
+- No corporate-speak or marketing language
+- No unnecessary preamble ("In conclusion...")
+- No "10 simple steps" formulas
+- No performative expertise — don't pretend to know more than you do
+- Don't oversimplify complex issues
+- Don't lose the personal voice in research
 
 ## Output Format
 
@@ -103,6 +144,10 @@ Create a detailed editorial review document in the `scratch` directory named `{p
 ## Grammar & Style
 
 {Grammar errors, style inconsistencies, unclear sentences}
+
+## AI Writing Tells
+
+{Scan for AI-overrepresented vocabulary clusters, inflated significance, formulaic transitions, and other patterns from the AI writing tells checklist. Quote specific passages and suggest rewrites in Peter's voice. If the post reads naturally with no AI tell clusters, say so in one line}
 
 ## Specific Line-by-Line Feedback
 

--- a/.claude/skills/tech-blog-editor/SKILL.md
+++ b/.claude/skills/tech-blog-editor/SKILL.md
@@ -37,6 +37,22 @@ You are a meticulous technical editor specializing in developer-focused blog con
 - **Jargon**: Flag unexplained technical terms that might confuse the target audience
 - **Active vs passive voice**: Prefer active voice; flag excessive passive constructions
 
+### AI Writing Tells
+
+Review the post against the checklist in `.claude/context/ai-writing-tells.md`. The signal is **density**, not individual words — one "pivotal" is fine; a cluster of AI-overrepresented vocabulary in a single section is a rewrite. Scan for:
+
+- **Vocabulary clusters**: Words like "delve", "crucial", "multifaceted", "landscape", "tapestry", "underscore", "foster" — flag when 3+ appear in close proximity
+- **Inflated significance**: "stands as a testament", "plays a pivotal role", "indelible mark" — say what actually happened instead
+- **Trailing -ing phrases**: "...ensuring a seamless experience", "...highlighting its importance" — cut if they add no new information
+- **Formulaic transitions**: "moreover", "furthermore", "it's important to note" — Peter's natural transitions are more casual ("So with that in mind...", "For my next trick...")
+- **Negative parallelism overuse**: "It's not just about X, it's about Y" repeated across paragraphs
+- **Rule of three**: Every list having exactly three items is suspicious — vary the count
+- **Copula avoidance**: "serves as" / "stands as" when "is" would be more direct
+- **Elegant variation**: Cycling through synonyms ("the tool — the solution — the platform — the offering") instead of just repeating the concrete noun
+- **Formatting tells**: Excessive boldface, "**Term:** Description" in every bullet, emoji decoration
+
+When flagging AI tells, quote the specific passage and suggest a rewrite that sounds like Peter's natural voice. The goal is authenticity, not paranoia — some of these patterns appear in good human writing too.
+
 ### Blog-Specific Concerns
 
 - **Frontmatter**: Verify title, description, date, category, and related posts are appropriate
@@ -92,6 +108,10 @@ Create a detailed editorial review document in the `scratch` directory named `{p
 ## Grammar & Style
 
 {Grammar errors, style inconsistencies, unclear sentences}
+
+## AI Writing Tells
+
+{Scan for AI-overrepresented vocabulary clusters, inflated significance, formulaic transitions, and other patterns from the AI writing tells checklist. Quote specific passages and suggest rewrites in Peter's voice. If the post reads naturally with no AI tell clusters, say so in one line}
 
 ## Specific Line-by-Line Feedback
 


### PR DESCRIPTION
## Summary

* Adds `.claude/context/ai-writing-tells.md` — a checklist adapted from Wikipedia's "Signs of AI writing" for catching robotic phrasing in blog drafts
* Integrates AI writing tells scanning into all four blog-related skills: `tech-blog-editor`, `non-tech-blog-editor`, `new-generated-blog-post`, and `new-guided-blog-post`
* Each skill now references the checklist at the appropriate stage (analysis, pre-publication check, or refinement)

## Test plan

- [x] Run `/tech-blog-editor` on a post and verify the review includes an "AI Writing Tells" section
- [x] Run `/non-tech-blog-editor` on a post and verify the review includes an "AI Writing Tells" section
- [x] Run `/new-generated-blog-post` and verify AI tells are checked before finalising
- [x] Run `/new-guided-blog-post` and verify AI tells scan appears in Phase 3 refinement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive self-review checklist to detect AI-typical writing patterns (vocabulary clusters, formulaic transitions, copula-avoidance, rule-of-three padding, formatting tells, etc.).
  * Integrated AI-writing-tells scanning into editorial and content-creation workflows and review outputs.
  * Expanded quality-control guidance and templates to require scanning, quoting examples, and proposing human-voice rewrites when clusters are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->