### PR TITLE
chore: add shared Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "mcp__unsplash__search_photos",
+      "mcp__unsplash__get_photo_attribution"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ hugo_cache
 # Testing
 coverage
 
+# Claude Code (user-local settings, not committed)
+.claude/*.local.json
+.claude/*.local.md
+
 # Scratch directory (keep dir, ignore contents)
 scratch/*
 !scratch/.gitkeep


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with shared project permission allowlist (WebSearch, Unsplash tools)
- Add `.claude/*.local.json` and `*.local.md` to `.gitignore` per official Claude Code guidance to keep user-local settings out of version control

## Test plan
- [ ] Verify `.claude/settings.json` is picked up by Claude Code sessions
- [ ] Verify `.claude/settings.local.json` is properly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled WebSearch and Unsplash photo integration capabilities in system settings.
  * Updated repository configuration to exclude local settings files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->