### PR TITLE
docs(agents): add URL permalink pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ public/                # Generated site (not in git)
 - **Hosting**: S3 (eu-west-1) + CloudFront CDN + Route53 DNS, managed via Terraform in `terraform/s3-website/`
 - **Deployment**: GitHub Actions on push to `master` using OIDC auth (no static AWS keys). Vercel previews for PRs.
 - **Theme**: PaperMod (git submodule). Custom partials in `layouts/partials/`. Extension hook: `layouts/partials/extend_head.html`
-- **URLs**: PrettyURLs via S3 static website hosting + Hugo permalink config. To change URL style, update both `hugo.yaml` and `terraform/s3-website/main.tf`
+- **URLs**: PrettyURLs via S3 static website hosting + Hugo permalink config (`/:title/`). Blog post URLs resolve to `https://petersouter.xyz/<slug>/` where `<slug>` is the `slug` frontmatter field (no date path segments). To change URL style, update both `hugo.yaml` and `terraform/s3-website/main.tf`
 - **Custom functionality**: Talks page filter (`layouts/partials/talks-list.html` + `static/js/talks-filter.js`)
 
 ## Git Workflow


### PR DESCRIPTION
## Summary

* Document the `/:title/` permalink convention in AGENTS.md
* Clarify that blog post URLs use the `slug` frontmatter field with no date path segments (e.g. `https://petersouter.xyz/april-update-gardens-grass-and-big-fish/`)

## Test plan

- [ ] Verify AGENTS.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated URL scheme documentation to clarify blog post paths now use slug-based structure without date-based segments
  * Clarified Hugo permalink configuration requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->