### PR TITLE
feat: add better blockquote quote formatting

### DIFF
--- a/assets/css/extended/blockquote.css
+++ b/assets/css/extended/blockquote.css
@@ -1,6 +1,9 @@
 /* Blockquote with author attribution
  * Adapted from: https://discourse.gohugo.io/t/generating-the-author-of-a-quote-blockquote/19200
  *
+ * A render hook (render-blockquote.html) adds the .quote-with-attribution
+ * class to blockquotes with exactly two <p> elements (quote + author).
+ *
  * Usage in markdown:
  *   > Quote text here
  *   >
@@ -9,40 +12,14 @@
  * When a blockquote has two <p> elements, the first gets opening curly quotes
  * and the last is styled as an attribution line (italic, preceded by em-dash).
  * A single-<p> blockquote gets balanced open/close quotes with no attribution.
+ * Blockquotes with 3+ paragraphs are left unstyled.
  */
 
-blockquote p {
-    display: inline;
-}
-
-/* First paragraph: open quote */
-blockquote p:first-of-type {
+blockquote {
     quotes: '\201C' '\201D' '\2018' '\2019';
 }
 
-blockquote p:first-of-type::before {
-    content: open-quote;
-    margin-right: 0.1rem;
-}
-
-/* Last paragraph (when there are multiple): attribution line */
-blockquote p:last-of-type {
-    quotes: '\201C' '\201D' '\2018' '\2019';
-    font-style: italic;
-}
-
-blockquote p:last-of-type::before {
-    content: close-quote "\000A" "\2014" " ";
-    white-space: pre;
-    margin-left: 0.1rem;
-    font-style: normal;
-}
-
-/* Only paragraph (no attribution): balanced open/close quotes */
-blockquote p:only-of-type {
-    font-style: normal;
-    quotes: '\201C' '\201D' '\2018' '\2019';
-}
+/* --- Single-paragraph blockquote: balanced open/close quotes --- */
 
 blockquote p:only-of-type::before {
     content: open-quote;
@@ -52,4 +29,28 @@ blockquote p:only-of-type::before {
 blockquote p:only-of-type::after {
     content: close-quote;
     margin-left: 0.1rem;
+}
+
+/* --- Two-paragraph blockquote (quote + attribution) --- */
+
+/* Open quote on the first paragraph */
+.quote-with-attribution p:first-of-type::before {
+    content: open-quote;
+    margin-right: 0.1rem;
+}
+
+/* Close quote on the first paragraph (before the attribution) */
+.quote-with-attribution p:first-of-type::after {
+    content: close-quote;
+    margin-left: 0.1rem;
+}
+
+/* Attribution line: italic with em-dash prefix */
+.quote-with-attribution p:last-of-type {
+    font-style: italic;
+}
+
+.quote-with-attribution p:last-of-type::before {
+    content: "\2014" " ";
+    font-style: normal;
 }

--- a/assets/css/extended/blockquote.css
+++ b/assets/css/extended/blockquote.css
@@ -1,0 +1,55 @@
+/* Blockquote with author attribution
+ * Adapted from: https://discourse.gohugo.io/t/generating-the-author-of-a-quote-blockquote/19200
+ *
+ * Usage in markdown:
+ *   > Quote text here
+ *   >
+ *   > Author Name
+ *
+ * When a blockquote has two <p> elements, the first gets opening curly quotes
+ * and the last is styled as an attribution line (italic, preceded by em-dash).
+ * A single-<p> blockquote gets balanced open/close quotes with no attribution.
+ */
+
+blockquote p {
+    display: inline;
+}
+
+/* First paragraph: open quote */
+blockquote p:first-of-type {
+    quotes: '\201C' '\201D' '\2018' '\2019';
+}
+
+blockquote p:first-of-type::before {
+    content: open-quote;
+    margin-right: 0.1rem;
+}
+
+/* Last paragraph (when there are multiple): attribution line */
+blockquote p:last-of-type {
+    quotes: '\201C' '\201D' '\2018' '\2019';
+    font-style: italic;
+}
+
+blockquote p:last-of-type::before {
+    content: close-quote "\000A" "\2014" " ";
+    white-space: pre;
+    margin-left: 0.1rem;
+    font-style: normal;
+}
+
+/* Only paragraph (no attribution): balanced open/close quotes */
+blockquote p:only-of-type {
+    font-style: normal;
+    quotes: '\201C' '\201D' '\2018' '\2019';
+}
+
+blockquote p:only-of-type::before {
+    content: open-quote;
+    margin-right: 0.1rem;
+}
+
+blockquote p:only-of-type::after {
+    content: close-quote;
+    margin-left: 0.1rem;
+}

--- a/content/garden/concepts/conciseness/index.md
+++ b/content/garden/concepts/conciseness/index.md
@@ -10,28 +10,36 @@ Conciseness is something I struggle with. I know the value of being brief, I adm
 
 Here are some quotes from people who were better at it than me:
 
-> "I didn't have time to write you a short letter, so I wrote you a long one."
-> -- Blaise Pascal
+> I didn't have time to write you a short letter, so I wrote you a long one.
+>
+> Blaise Pascal
 
-> "Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away."
-> -- Antoine de Saint-Exupery
+> Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away.
+>
+> Antoine de Saint-Exupery
 
-> "Brevity is the soul of wit."
-> -- William Shakespeare, *Hamlet*
+> Brevity is the soul of wit.
+>
+> William Shakespeare, *Hamlet*
 
-> "The most valuable of all talents is that of never using two words when one will do."
-> -- Thomas Jefferson
+> The most valuable of all talents is that of never using two words when one will do.
+>
+> Thomas Jefferson
 
-> "Omit needless words."
-> -- Strunk & White, *The Elements of Style*
+> Omit needless words.
+>
+> Strunk & White, *The Elements of Style*
 
-> "If you can't explain it simply, you don't understand it well enough."
-> -- Albert Einstein
+> If you can't explain it simply, you don't understand it well enough.
+>
+> Albert Einstein
 
-> "Good prose is like a windowpane."
-> -- George Orwell
+> Good prose is like a windowpane.
+>
+> George Orwell
 
-> "Not that the story need be long, but it will take a long while to make it short."
-> -- Henry David Thoreau
+> Not that the story need be long, but it will take a long while to make it short.
+>
+> Henry David Thoreau
 
 The irony of collecting this many quotes about brevity is not lost on me.

--- a/content/post/2026/03/i-failed-but-feel-good/index.md
+++ b/content/post/2026/03/i-failed-but-feel-good/index.md
@@ -134,8 +134,8 @@ Or even simpler "Isn't this supposed to be fun?" hence vexillology and having a 
 As I was quickly running the "git commit and merge straight to prod branch yolo mode to speed things up", I had a flashback to a study that I'd intended to use as my central thesis of my "Staying Human in the age of AI" blog...
 
 > Despite the performance benefits, participants who collaborated with gen AI on one task and then transitioned to a different, unaided task consistently reported a decline in intrinsic motivation and an increase in boredom. Across our studies, intrinsic motivation dropped by an average of 11% and boredom increased by an average of 20%. In contrast, those who worked without AI maintained a relatively steady psychological state.
-
-[Research: Gen AI Makes People More Productive—and Less Motivated, by Yukun Liu, Suqing Wu, Mengqi Ruan, Siyu Chen and Xiao-Yun Xie](https://hbr.org/2025/05/research-gen-ai-makes-people-more-productive-and-less-motivated)
+>
+> [Research: Gen AI Makes People More Productive—and Less Motivated](https://hbr.org/2025/05/research-gen-ai-makes-people-more-productive-and-less-motivated), by Yukun Liu, Suqing Wu, Mengqi Ruan, Siyu Chen and Xiao-Yun Xie
 
 Hmm, so...you've got an ever increasing backlog of ideas, you're solving them with AI and improving the core work, but you're not scratching that loop of satisfaction when you deliver.
 

--- a/layouts/_default/_markup/render-blockquote.html
+++ b/layouts/_default/_markup/render-blockquote.html
@@ -1,0 +1,5 @@
+{{- $text := .Text -}}
+{{- $paraCount := len (findRE "<p>" $text) -}}
+<blockquote{{ if eq $paraCount 2 }} class="quote-with-attribution"{{ end }}>
+  {{ $text }}
+</blockquote>


### PR DESCRIPTION
## Summary
- Adds CSS-based blockquote styling that automatically adds curly quotes and em-dash author attribution, adapted from [this Hugo discourse post](https://discourse.gohugo.io/t/generating-the-author-of-a-quote-blockquote/19200)
- Updates conciseness garden page quotes to use the new two-paragraph blockquote format (quote + attribution separated by blank `>` line)
- Updates the HBR research quote in the "I Failed But Feel Good" post to use the same format

## Test plan
- [ ] Verify blockquotes with attribution render with curly quotes and em-dash on the conciseness garden page
- [ ] Verify single-paragraph blockquotes still render with balanced open/close quotes
- [ ] Verify the HBR quote in the i-failed-but-feel-good post renders correctly
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved blockquote presentation with automatic typographic quotation marks and clearer attribution styling for two-line quotes.
  * Single-paragraph and multi-paragraph quotes now render more consistently.

* **Documentation**
  * Standardized quote formatting across site content for improved readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->