### PR TITLE
feat(garden): add Ma (間) garden page

### DIFF
--- a/content/garden/concepts/ma/index.md
+++ b/content/garden/concepts/ma/index.md
@@ -1,0 +1,74 @@
+---
+title: "Ma (間)"
+date: 2026-04-13T00:00:00+00:00
+description: "The Japanese concept of intentional negative space - and why it stuck with me since film studies."
+garden_topic: "Concepts"
+status: "Seedling"
+---
+
+Ma (間) is a Japanese concept that roughly translates to "the space between things", but specifically *intentional* negative space.
+
+Way back in the day, when I was doing A-Level Film Studies was the first time I'd heard it, and that original memory was re-sparked for me recently watching this YouTube short of Brennan Lee Mulligan and Matt Mercer (of Critical Role fame for ya'll non-nerds out there) talking about Ma in the context of *Seven Samurai* and Kurosawa:
+
+{{< youtube tDS2olk8Jx0 >}}
+
+Now I wish I could be cool enough to say my first experience with Ma was with a Kurosawa picture, but it was actually with Miyazaki of Ghibli fame. I think Spirited Away (2003 western release)? Because that lines up with his interview with Roger Ebert when he talked about Ma in 2002 so I imagine that might have been one of the sources we'd referenced in class:
+
+> "The time in between my clapping is ma. If you just have nonstop action with no breathing space at all, it's just busyness. But if you take a moment, then the tension building in the film can grow into a wider dimension. If you just have constant tension at 80 degrees all the time, you just get numb."
+>
+> Hayao Miyazaki, Source: [Drawing on 'Spirited' world, September 19, 2002, BY ROGER EBERT](https://web.archive.org/web/20020925093723/http://www.suntimes.com/output/eb-feature/cst-ftr-ebert19.html)
+
+Now, once you know about Ma, you see it everywhere, even outside of Japanese media and culture. Miles Davis said he built his trumpet style on the notes he _didn't_ play:
+
+> In music, silence is more important than sound
+>
+> Miles Davis... (Or is it?)
+
+Very Ma, but honestly that's a pretty apocryphal quote, also attributed to Debussy and Mozart. 
+
+It's one of those concepts that, once you've got the word for it, you start spotting it constantly, and it applies in a lot of areas.
+
+Design, music, writing, storytelling and conversation. As someone who's always thinking about [conciseness](/garden/concepts/conciseness/), it's another idea I try to be mindful of.
+
+## So... Why this is a garden post and not a blog post?
+
+This is something I've been itching to turn into a blog post but I can't think of a way of doing this... 
+
+Tastefully? 
+
+Or even more bluntly... done well?
+
+I actually had a rough go at a full blog post about this called "Ma: What Kurosawa Can Teach Us About Not Shipping AI Slop" - connecting Ma to generative AI, agentic workflows, the whole thing. But reading it back, it felt too LinkedIn-bait and a bit pretentious.
+
+Plus, to put it bluntly, a western white guy invoking Eastern philosophy to make a point about technology, especially when Miyazaki himself had very strong feelings about GenAI content:
+
+{{< youtube ngZ0K3lWKRc >}}
+
+> I am utterly disgusted… I strongly feel that this is an insult to life itself.”
+> 
+> Miyazaki 
+
+[Ironic considering the GenAI art trend of people using his style for profile pictures and such right?](https://www.independent.co.uk/arts-entertainment/films/news/hayao-miyazaki-studio-ghibli-ai-trend-b2723358.html)
+
+But I liked the writing I'd done about Ma itself and didn't want to waste it, so into the garden it went. 
+
+It lives here both as storage for that work and as something that might eventually grow into a proper post with a direction I'm happier with.
+
+But in the mean-time it's a little reminder of a great core philosophy 
+
+As well as an opportunity to have a little Ma moment...
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+See? You feel better already now you've had that little break!


### PR DESCRIPTION
## Summary
- Adds a new garden page on Ma (間), the Japanese concept of intentional negative space
- Includes YouTube embeds (Brennan Lee Mulligan/Matt Mercer on Kurosawa, Miyazaki's GenAI reaction)
- Cross-links to the conciseness garden page
- Personal voice throughout with interactive Ma moment at the end

## Test plan
- [ ] `hugo server` and visit `/garden/concepts/ma/`
- [ ] Verify YouTube embeds render correctly
- [ ] Verify conciseness cross-link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published a new article exploring Ma (間), the Japanese concept of intentional negative space, featuring cinematic examples, animation references, embedded video content, and connections to design, writing, and artistic disciplines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->