### PR TITLE
fix: resolve Vercel build errors for bluesky shortcode and pnpm

### DIFF
--- a/.github/workflows/deploy-vercel-preview.yml
+++ b/.github/workflows/deploy-vercel-preview.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: amondnet/vercel-action@v42.1.0
+      - uses: amondnet/vercel-action@v42.2.0
         with:
          vercel-token: ${{ secrets.VERCEL_TOKEN }}
          vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}

--- a/layouts/shortcodes/bluesky.html
+++ b/layouts/shortcodes/bluesky.html
@@ -2,17 +2,15 @@
 {{- if $link -}}
   {{- $query := querify "url" $link "format" "json" -}}
   {{- $request := printf "https://embed.bsky.app/oembed?%s" $query -}}
-  {{- with resources.GetRemote $request -}}
+  {{- with try (resources.GetRemote $request) -}}
     {{- with .Err -}}
       {{- warnf "bluesky shortcode: failed to fetch oEmbed for %q: %s" $link . -}}
-    {{- else -}}
+    {{- else with .Value -}}
       {{- $jsonOembed := unmarshal .Content -}}
       {{- with $jsonOembed.html -}}
         {{- . | safeHTML -}}
       {{- end -}}
     {{- end -}}
-  {{- else -}}
-    {{- warnf "bluesky shortcode: no response fetching oEmbed for %q" $link -}}
   {{- end -}}
 {{- else -}}
   {{- warnf "bluesky shortcode: missing required \"link\" parameter" -}}

--- a/layouts/shortcodes/bluesky.html
+++ b/layouts/shortcodes/bluesky.html
@@ -2,17 +2,17 @@
 {{- if $link -}}
   {{- $query := querify "url" $link "format" "json" -}}
   {{- $request := printf "https://embed.bsky.app/oembed?%s" $query -}}
-  {{- with try (resources.GetRemote $request) -}}
+  {{- with resources.GetRemote $request -}}
     {{- with .Err -}}
       {{- warnf "bluesky shortcode: failed to fetch oEmbed for %q: %s" $link . -}}
     {{- else -}}
-      {{- with .Value -}}
-        {{- $jsonOembed := unmarshal .Content -}}
-        {{- with $jsonOembed.html -}}
-          {{- . | safeHTML -}}
-        {{- end -}}
+      {{- $jsonOembed := unmarshal .Content -}}
+      {{- with $jsonOembed.html -}}
+        {{- . | safeHTML -}}
       {{- end -}}
     {{- end -}}
+  {{- else -}}
+    {{- warnf "bluesky shortcode: no response fetching oEmbed for %q" $link -}}
   {{- end -}}
 {{- else -}}
   {{- warnf "bluesky shortcode: missing required \"link\" parameter" -}}

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- **Fix Hugo build error**: Rewrite `bluesky.html` shortcode to remove the `try` function (Hugo v0.141.0+), using the classic `resources.GetRemote` + `.Err` pattern instead. Vercel's build wasn't honoring `HUGO_VERSION` from `build.env` when a custom `buildCommand` is used, so the shortcode failed on the older default Hugo.
- **Fix pnpm warning**: Add `pnpm.onlyBuiltDependencies: ["unrs-resolver"]` to `package.json` to silence the pnpm v10 "ignored build scripts" warning for `unrs-resolver` (a transitive dep of `jest-runner`).

## Test plan

- [ ] Verify Vercel preview deployment builds successfully without the `try` function error
- [ ] Verify pnpm install no longer shows the "Ignored build scripts: unrs-resolver" warning
- [ ] Confirm bluesky embeds still render correctly on pages that use the shortcode

https://claude.ai/code/session_01NC1kVYvLFdyKeFzHLE2wQv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified Bluesky oEmbed handling with clearer warnings when remote fetches fail; behavior and rendering remain unchanged.

* **Chores**
  * Updated the Vercel preview deployment action to a newer release.
  * Adjusted package manager build configuration to limit built dependencies and streamline the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->