### PR TITLE
claude/update-skill-context-Rdc5V

### DIFF
--- a/.claude/context/ai-writing-tells.md
+++ b/.claude/context/ai-writing-tells.md
@@ -115,12 +115,12 @@ If you're talking about Hugo, just say Hugo again. If you're talking about Terra
 
 ## Em dash overuse
 
-LLMs use em dashes at 2-3x the rate of human writers. They substitute them for commas, parentheses, and colons in a formulaic, "punched up" style. When every other sentence has one, or when a comma would be more natural, it's a tell.
+Remove all em dashes. Em dashes are now so strongly associated with AI-generated text that even a single one damages credibility. Their reputation is too tarnished to salvage — the association is instant and automatic for anyone who reads a lot of LLM output. Use a comma, parentheses, a colon, or restructure the sentence. Never use an em dash.
 
 ## Formatting tells
 
 - **Excessive boldface**: bolding every key term mechanically, "key takeaways" style
-- **Title case in every heading**: use sentence case instead
+- **Sentence case headings**: always use Title Case for headings and headlines — every significant word capitalised
 - **Bullet + bold header + colon**: the "**Term:** Description of term" pattern in every list
 - **Emoji decoration**: emoji before every section heading or bullet point
 

--- a/.claude/context/writing-style.md
+++ b/.claude/context/writing-style.md
@@ -19,7 +19,7 @@ Conversational, self-aware, and technically grounded with a strong emphasis on h
 - Phrases like "So let's...", "Enter:", "Honestly" to create casual rapport
 - Comfortable admitting gaps: "honestly the alternative solutions aren't perfect either"
 - Parenthetical asides are frequent: "(way back in **2011**)", "(as is the case recently)"
-- Em-dashes for inline clarifications and asides
+- Parenthetical asides for inline clarifications (use parentheses, not em-dashes)
 
 ### Vulnerability
 Peter openly admits uncertainty, incomplete knowledge, and confusion. He never pretends to have all the answers.
@@ -56,7 +56,8 @@ Establishes personal stakes before diving into technical content.
 
 ### Section Organization
 - H2/H3 headers used liberally to break up content
-- Headers are descriptive and sometimes playful: "Too quiet", "Enter Boxen", "Turtles all the way down"
+- Headers are descriptive and sometimes playful: "Too Quiet", "Enter Boxen", "Turtles All the Way Down"
+- All headers and headlines use Title Case regardless of length or grammar rules
 - Numbered lists for sequential/chronological content
 - Bullet points for parallel ideas
 - Bold emphasis for key takeaways
@@ -244,7 +245,7 @@ When writing in Peter's voice:
 3. Be honest about what you don't know and what went wrong — vulnerability builds credibility
 4. Use specific details: real tools, real commands, real error messages
 5. Let enthusiasm for the technical details come through naturally
-6. Use parenthetical asides, em-dashes, and varied sentence lengths for personality
+6. Use parenthetical asides and varied sentence lengths for personality (never em-dashes)
 7. Use headers and lists generously for scannability
 8. Include code examples with context — show first, explain second
 9. Close with forward momentum, not grand conclusions


### PR DESCRIPTION
Em-dashes are now too tarnished by AI slop association to use at all.
Headlines and headers should always use Title Case.

https://claude.ai/code/session_01UFWPMmLRRPux9bj4ReMWQn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated punctuation guidance for inline clarifications
  * Standardized heading capitalization rules across all headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->