### PR TITLE
feat(skills): add personal style overrides

### DIFF
--- a/.claude/context/ai-writing-tells.md
+++ b/.claude/context/ai-writing-tells.md
@@ -4,6 +4,16 @@ Adapted from [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wiki
 
 This checklist is **descriptive, not prescriptive**. A few of these patterns appear naturally in good human writing. The signal is density - one "pivotal" is fine; five AI vocabulary words in two paragraphs is a rewrite.
 
+## Personal Style Overrides
+
+A few patterns in this checklist are genuine AI tells, but Peter prefers them in his own writing. These overrides are deliberate - do not "correct" them during drafting or review:
+
+- **Title Case for All Headings (H1, H2, H3).** LLMs overuse Title Case (see Formatting tells below). Peter uses it anyway: it reads cleaner on his site and matches his aesthetic preference. Sentence case is not the house style.
+- **Title Case for Bold Prefixes in Headline-Style Bullets.** Bullets of the shape `**Term:** description` use Title Case on the term (Chicago style: capitalize principal words; lowercase articles, short prepositions, coordinating conjunctions). Plain prose bullets keep natural sentence case.
+- **Zero Em-Dashes and Zero En-Dashes in Prose.** LLMs overuse em-dashes (see Em dash overuse below). Peter's rule is stricter than the checklist: none at all in published content. Use a hyphen (-), parentheses, a comma, or a colon. Applies even to number ranges (`5-10 minutes`, not `5–10 minutes`). Verbatim quotes from external sources are exempt.
+
+When editing or reviewing Peter's content: do not flag Title Case headings or `**Term:**` bullet prefixes as AI tells. Do flag every em-dash and en-dash as a hard error, stricter than the general "overuse" framing below.
+
 ## Overused AI vocabulary
 
 Words that spiked in frequency after 2023, corroborated by peer-reviewed studies. Scan for clusters of these:
@@ -115,12 +125,14 @@ If you're talking about Hugo, just say Hugo again. If you're talking about Terra
 
 ## Em dash overuse
 
-LLMs use em dashes at 2-3x the rate of human writers. They substitute them for commas, parentheses, and colons in a formulaic, "punched up" style. When every other sentence has one, or when a comma would be more natural, it's a tell.
+**Personal override applies - see Personal Style Overrides at the top of this file.** Peter bans em-dashes and en-dashes entirely in his content.
+
+LLMs use em dashes at 2-3x the rate of human writers. They substitute them for commas, parentheses, and colons in a formulaic, "punched up" style. In Peter's writing, replace every em-dash (—) and en-dash (–) with one of: a hyphen (-), parentheses, a comma, or a colon. Applies to number ranges too (`5-10 minutes`, not `5–10 minutes`). Verbatim quotes from external sources are exempt.
 
 ## Formatting tells
 
 - **Excessive boldface**: bolding every key term mechanically, "key takeaways" style
-- **Title case in every heading**: use sentence case instead
+- **Title case in every heading**: genuine AI tell in most contexts, but Peter's personal override (see top of file) keeps Title Case for all H1/H2/H3 headings and for bold prefixes in headline-style bullets. Do not flag these in his content.
 - **Bullet + bold header + colon**: the "**Term:** Description of term" pattern in every list
 - **Emoji decoration**: emoji before every section heading or bullet point
 

--- a/.claude/context/ai-writing-tells.md
+++ b/.claude/context/ai-writing-tells.md
@@ -132,7 +132,7 @@ LLMs use em dashes at 2-3x the rate of human writers. They substitute them for c
 ## Formatting tells
 
 - **Excessive boldface**: bolding every key term mechanically, "key takeaways" style
-- **Title case in every heading**: genuine AI tell in most contexts, but Peter's personal override (see top of file) keeps Title Case for all H1/H2/H3 headings and for bold prefixes in headline-style bullets. Do not flag these in his content.
+- **Title Case in Every Heading**: genuine AI tell in most contexts, but Peter's personal override (see top of file) keeps Title Case for all H1/H2/H3 headings and for bold prefixes in headline-style bullets. Do not flag these in his content.
 - **Bullet + bold header + colon**: the "**Term:** Description of term" pattern in every list
 - **Emoji decoration**: emoji before every section heading or bullet point
 

--- a/.claude/context/writing-style.md
+++ b/.claude/context/writing-style.md
@@ -19,7 +19,7 @@ Conversational, self-aware, and technically grounded with a strong emphasis on h
 - Phrases like "So let's...", "Enter:", "Honestly" to create casual rapport
 - Comfortable admitting gaps: "honestly the alternative solutions aren't perfect either"
 - Parenthetical asides are frequent: "(way back in **2011**)", "(as is the case recently)"
-- Em-dashes for inline clarifications and asides
+- Parenthetical asides, commas, and colons for inline clarifications (no em-dashes or en-dashes - see Heading Case and Dash Conventions below)
 
 ### Vulnerability
 Peter openly admits uncertainty, incomplete knowledge, and confusion. He never pretends to have all the answers.
@@ -43,6 +43,16 @@ Posts often follow a practitioner's journey: **personal problem or context → e
 - **Planning posts**: Optimistic with self-aware hedging about ambition
 
 ## Structural Patterns
+
+### Heading Case and Dash Conventions
+
+Two firm house-style rules that override the AI-writing-tells checklist:
+
+- **Title Case on Every Heading** (H1, H2, H3). Chicago style: capitalize principal words; lowercase articles, short prepositions, and coordinating conjunctions.
+- **Title Case on Bold Prefixes in Headline-Style Bullets** - bullets of the shape `**Term:** description`. Plain prose bullets keep natural sentence case.
+- **No Em-Dashes (—) and No En-Dashes (–) in Prose.** Use a hyphen (-), parentheses, commas, or colons. Number ranges use a hyphen (`5-10 minutes`). Verbatim quotes from external sources keep their original punctuation.
+
+These are deliberate preferences that override the AI-writing-tells guide. See `.claude/context/ai-writing-tells.md` § Personal Style Overrides for the reasoning.
 
 ### Opening Hooks
 Varied but always personal or relatable — leads with personal context or a practical problem, not dramatic hooks:
@@ -244,7 +254,7 @@ When writing in Peter's voice:
 3. Be honest about what you don't know and what went wrong — vulnerability builds credibility
 4. Use specific details: real tools, real commands, real error messages
 5. Let enthusiasm for the technical details come through naturally
-6. Use parenthetical asides, em-dashes, and varied sentence lengths for personality
+6. Use parenthetical asides, short punchy sentences, and varied sentence lengths for personality (no em-dashes or en-dashes)
 7. Use headers and lists generously for scannability
 8. Include code examples with context — show first, explain second
 9. Close with forward momentum, not grand conclusions

--- a/.claude/skills/new-garden-page/SKILL.md
+++ b/.claude/skills/new-garden-page/SKILL.md
@@ -92,9 +92,8 @@ Use the page name (not the topic) for the branch: `feat/garden/cold-brew`, `feat
 Garden pages are informal, but accuracy still matters.
 
 - If the user provided links, read them with WebFetch
-- If the topic references tools, commands, or facts — verify them
+- If the topic references tools, commands, or facts, verify them
 - Check existing garden pages in the same topic for tone and format consistency: `ls content/garden/<topic>/`
-- Check existing blog posts for potential cross-links: `find content/post/ -name "*.md" | sort`
 
 Don't over-research. The garden is a scratchpad, not a research paper.
 
@@ -127,12 +126,12 @@ Peter's voice applies here just as much as in blog posts, but the format is diff
 
 Read `.claude/context/writing-style.md` for the full voice guide. The key points for garden content:
 
-- **First-person, conversational**: "I learnt about...", "I've been using..."
+- **First-Person, Conversational**: "I learnt about...", "I've been using..."
 - **British English**: recognised, organised, colour, favourite
-- **No preamble**: Jump straight into the idea. No "In this page, I'll discuss..."
-- **Short paragraphs**: 1-3 sentences each. White space is your friend.
-- **Honest and casual**: Incomplete thoughts are fine. "I'm not sure about this yet" is valid garden content.
-- **Links are generous**: Link to sources, tools, people, other garden pages, blog posts
+- **No Preamble**: Jump straight into the idea. No "In this page, I'll discuss..."
+- **Short Paragraphs**: 1-3 sentences each. White space is your friend.
+- **Honest and Casual**: Incomplete thoughts are fine. "I'm not sure about this yet" is valid garden content.
+- **Links Are Generous**: Link to sources, tools, people, other garden pages, blog posts
 
 #### Content Guidelines
 
@@ -177,10 +176,13 @@ If the user provides images, copy them into the page bundle directory.
 
 Review the draft against `.claude/context/ai-writing-tells.md`. Garden pages are short, so even a small cluster stands out. Watch for:
 
-- AI vocabulary ("delve", "crucial", "landscape", "foster") — replace with plain language
-- Inflated significance — garden pages are casual; nothing needs to "stand as a testament"
-- Formulaic transitions — in a short page, "moreover" and "furthermore" stick out badly
-- Promotional tone — no "stunning", "groundbreaking", "renowned"
+- AI vocabulary ("delve", "crucial", "landscape", "foster"): replace with plain language
+- Inflated significance: garden pages are casual; nothing needs to "stand as a testament"
+- Formulaic transitions: in a short page, "moreover" and "furthermore" stick out badly
+- Promotional tone: no "stunning", "groundbreaking", "renowned"
+- **Em-dashes and en-dashes**: Zero of either in the content. Hyphen, parens, comma, or colon instead. Even for number ranges. Verbatim quotes from external sources are exempt.
+
+Note: Title Case on headings and on `**Term:**` bold bullet prefixes is Peter's house style, do NOT flag as AI tells.
 
 The signal is density. One instance in a long page is fine. In a 100-word garden page, one is already a cluster.
 

--- a/.claude/skills/new-generated-blog-post/SKILL.md
+++ b/.claude/skills/new-generated-blog-post/SKILL.md
@@ -202,17 +202,21 @@ Before finalising, review the draft against `.claude/context/ai-writing-tells.md
 - Inflated significance phrases ("stands as a testament", "plays a pivotal role")
 - Trailing -ing phrases that add no information ("...ensuring a seamless experience")
 - Formulaic transitions ("moreover", "furthermore", "it's important to note")
-- Every list having exactly three items — vary the count
+- Every list having exactly three items: vary the count
 - Copula avoidance ("serves as" when "is" is more direct)
 - Elegant variation (cycling through synonyms instead of repeating the concrete noun)
+- **Peter's overrides (do not flag)**: Title Case on every H1/H2/H3 heading and on bold prefixes of `**Term:** description` bullets. These are intentional.
+- **Zero em-dashes, zero en-dashes**: Search the draft for `—` and `–`. Every instance must be replaced with a hyphen (-), parentheses, a comma, or a colon. Number ranges included (`5-10`, not `5–10`). Verbatim quotes from external sources are exempt.
 
-The signal is density — one instance is fine; a cluster in a section means rewrite that section in Peter's natural voice.
+The signal is density: one instance is fine; a cluster in a section means rewrite that section in Peter's natural voice.
 
 #### Content Quality
 
 - [ ] `<!--more-->` is present after opening paragraph
 - [ ] British English spelling used throughout
 - [ ] No AI writing tell clusters (checked against `.claude/context/ai-writing-tells.md`)
+- [ ] No em-dashes (—) or en-dashes (–) anywhere in the post body (quotes exempt)
+- [ ] All headings (H1/H2/H3) use Title Case
 - [ ] Internal links to existing posts where relevant
 - [ ] External links to authoritative sources
 - [ ] No broken markdown links or image references

--- a/.claude/skills/new-generated-blog-post/SKILL.md
+++ b/.claude/skills/new-generated-blog-post/SKILL.md
@@ -206,7 +206,7 @@ Before finalising, review the draft against `.claude/context/ai-writing-tells.md
 - Copula avoidance ("serves as" when "is" is more direct)
 - Elegant variation (cycling through synonyms instead of repeating the concrete noun)
 - **Peter's overrides (do not flag)**: Title Case on every H1/H2/H3 heading and on bold prefixes of `**Term:** description` bullets. These are intentional.
-- **Zero em-dashes, zero en-dashes**: Search the draft for `—` and `–`. Every instance must be replaced with a hyphen (-), parentheses, a comma, or a colon. Number ranges included (`5-10`, not `5–10`). Verbatim quotes from external sources are exempt.
+- **Zero em-dashes, zero en-dashes in prose**: Search the draft's prose for `—` and `–`. Every instance must be replaced with a hyphen (-), parentheses, a comma, or a colon. Number ranges included (`5-10`, not `5–10`). Code blocks and verbatim quotes from external sources are exempt.
 
 The signal is density: one instance is fine; a cluster in a section means rewrite that section in Peter's natural voice.
 
@@ -215,7 +215,7 @@ The signal is density: one instance is fine; a cluster in a section means rewrit
 - [ ] `<!--more-->` is present after opening paragraph
 - [ ] British English spelling used throughout
 - [ ] No AI writing tell clusters (checked against `.claude/context/ai-writing-tells.md`)
-- [ ] No em-dashes (—) or en-dashes (–) anywhere in the post body (quotes exempt)
+- [ ] No em-dashes (—) or en-dashes (–) in prose (code blocks and verbatim quotes exempt)
 - [ ] All headings (H1/H2/H3) use Title Case
 - [ ] Internal links to existing posts where relevant
 - [ ] External links to authoritative sources

--- a/.claude/skills/new-guided-blog-post/SKILL.md
+++ b/.claude/skills/new-guided-blog-post/SKILL.md
@@ -20,7 +20,7 @@ Always apply Peter's writing voice from `.claude/context/writing-style.md`:
 
 ### Voice Characteristics
 - **First-person, conversational, personal**: Use "I've been", "I was tinkering", "I thought"
-- **Informal and friendly**: Use contractions liberally, parenthetical asides, em-dashes
+- **Informal and Friendly**: Use contractions liberally and parenthetical asides (no em-dashes or en-dashes - see `.claude/context/writing-style.md`)
 - **Self-deprecating humor**: Comfortable admitting gaps and mistakes
 - **Enthusiastic about discovery**: Genuine excitement about tools and technical solutions
 - **Honest and candid**: Not afraid to discuss struggles or incomplete projects
@@ -66,10 +66,10 @@ When the user describes what they want to write about:
 Work through the outline section by section:
 
 1. **Draft each section** following the style guide:
-   - Start with a personal hook — an experience, observation, or problem
+   - Start with a personal hook: an experience, observation, or problem
    - Be honest about what you don't know and what went wrong
    - Let enthusiasm for the technical details come through naturally
-   - Use parenthetical asides and em-dashes for personality
+   - Use parenthetical asides for personality (no em-dashes or en-dashes)
    - Include code examples with context, never bare code dumps
 
 2. **Iterate with feedback**:
@@ -101,7 +101,8 @@ Once the full draft is complete:
    - Check for clusters of AI-overrepresented vocabulary ("delve", "crucial", "multifaceted", "landscape", "tapestry", "underscore", "foster")
    - Remove inflated significance phrases, trailing -ing filler, and formulaic transitions
    - Vary list lengths (not always three items), prefer "is" over "serves as"/"stands as"
-   - The signal is density — one instance is fine; a cluster means rewrite in Peter's voice
+   - The signal is density: one instance is fine; a cluster means rewrite in Peter's voice
+   - Verify Peter's personal overrides: Title Case on every heading and on bold prefixes in headline bullets, and zero em-dashes or en-dashes anywhere in the body
 
 4. **Verify content quality**:
    - Technical claims are accurate

--- a/.claude/skills/non-tech-blog-editor/SKILL.md
+++ b/.claude/skills/non-tech-blog-editor/SKILL.md
@@ -67,8 +67,10 @@ Review the post against the checklist in `.claude/context/ai-writing-tells.md`. 
 - **Copula avoidance**: "serves as" / "stands as" when "is" would be more direct
 - **Elegant variation**: Cycling through synonyms ("the tool — the solution — the platform — the offering") instead of just repeating the concrete noun
 - **Formatting tells**: Excessive boldface, "**Term:** Description" in every bullet, emoji decoration
+- **Peter's personal overrides (do NOT flag as tells)**: Title Case headings (H1/H2/H3) and Title Case bold prefixes in `**Term:** description` bullets are Peter's house style, not AI tells. Do not suggest sentence-case rewrites for these.
+- **Em-dash and en-dash hard ban**: Peter treats every em-dash (—) and en-dash (–) as a hard error, stricter than the general "overuse" framing. Flag each instance and suggest replacement with a hyphen (-), parentheses, comma, or colon. Even number ranges: `5-10`, not `5–10`. Verbatim quotes from external sources are exempt.
 
-When flagging AI tells, quote the specific passage and suggest a rewrite that sounds like Peter's natural voice. The goal is authenticity, not paranoia — some of these patterns appear in good human writing too.
+When flagging AI tells, quote the specific passage and suggest a rewrite that sounds like Peter's natural voice. The goal is authenticity, not paranoia: some of these patterns appear in good human writing too.
 
 ### Engagement
 
@@ -84,7 +86,7 @@ Review and apply Peter's writing voice from `.claude/context/writing-style.md`:
 ### Voice Characteristics
 
 - **First-person, conversational, personal**: Use "I've been", "I was tinkering", "I thought"
-- **Informal and friendly**: Use contractions liberally, parenthetical asides, em-dashes
+- **Informal and Friendly**: Use contractions liberally and parenthetical asides (no em-dashes or en-dashes)
 - **Self-deprecating humor**: Comfortable admitting gaps and mistakes
 - **Enthusiastic about discovery**: Genuine excitement about expressing themselves and teaching new topics
 - **Honest and candid**: Not afraid to discuss struggles or incomplete projects
@@ -150,7 +152,9 @@ Create a detailed editorial review document in the `scratch` directory named `{p
 
 ## AI Writing Tells
 
-{Scan for AI-overrepresented vocabulary clusters, inflated significance, formulaic transitions, and other patterns from the AI writing tells checklist. Quote specific passages and suggest rewrites in Peter's voice. If the post reads naturally with no AI tell clusters, say so in one line}
+{Scan for AI-overrepresented vocabulary clusters, inflated significance, formulaic transitions, and other patterns from the AI writing tells checklist. Quote specific passages and suggest rewrites in Peter's voice. If the post reads naturally with no AI tell clusters, say so in one line.
+
+Em-dash and en-dash findings are hard errors, not stylistic suggestions: list them in a dedicated subsection and do not count them toward the Must Address cap. Suppressed Title Case flags (from Peter's personal override) do not need to be mentioned.}
 
 ## Specific Line-by-Line Feedback
 

--- a/.claude/skills/tech-blog-editor/SKILL.md
+++ b/.claude/skills/tech-blog-editor/SKILL.md
@@ -50,8 +50,10 @@ Review the post against the checklist in `.claude/context/ai-writing-tells.md`. 
 - **Copula avoidance**: "serves as" / "stands as" when "is" would be more direct
 - **Elegant variation**: Cycling through synonyms ("the tool — the solution — the platform — the offering") instead of just repeating the concrete noun
 - **Formatting tells**: Excessive boldface, "**Term:** Description" in every bullet, emoji decoration
+- **Peter's personal overrides (do NOT flag as tells)**: Title Case headings (H1/H2/H3) and Title Case bold prefixes in `**Term:** description` bullets are Peter's house style, not AI tells. Do not suggest sentence-case rewrites for these.
+- **Em-dash and en-dash hard ban**: Peter treats every em-dash (—) and en-dash (–) as a hard error, stricter than the general "overuse" framing. Flag each instance and suggest replacement with a hyphen (-), parentheses, comma, or colon. Even number ranges: `5-10`, not `5–10`. Verbatim quotes from external sources are exempt.
 
-When flagging AI tells, quote the specific passage and suggest a rewrite that sounds like Peter's natural voice. The goal is authenticity, not paranoia — some of these patterns appear in good human writing too.
+When flagging AI tells, quote the specific passage and suggest a rewrite that sounds like Peter's natural voice. The goal is authenticity, not paranoia: some of these patterns appear in good human writing too.
 
 ### Blog-Specific Concerns
 
@@ -111,7 +113,9 @@ Create a detailed editorial review document in the `scratch` directory named `{p
 
 ## AI Writing Tells
 
-{Scan for AI-overrepresented vocabulary clusters, inflated significance, formulaic transitions, and other patterns from the AI writing tells checklist. Quote specific passages and suggest rewrites in Peter's voice. If the post reads naturally with no AI tell clusters, say so in one line}
+{Scan for AI-overrepresented vocabulary clusters, inflated significance, formulaic transitions, and other patterns from the AI writing tells checklist. Quote specific passages and suggest rewrites in Peter's voice. If the post reads naturally with no AI tell clusters, say so in one line.
+
+Em-dash and en-dash findings are hard errors, not stylistic suggestions: list them in a dedicated subsection and do not count them toward the Must Address cap. Suppressed Title Case flags (from Peter's personal override) do not need to be mentioned.}
 
 ## Specific Line-by-Line Feedback
 


### PR DESCRIPTION
## Summary

- Added a `Personal Style Overrides` section to `ai-writing-tells.md` and a `Heading Case and Dash Conventions` subsection to `writing-style.md`. These make three deliberate departures from the AI-writing-tells checklist explicit and self-documenting rather than implicit:
  - **Title Case on all headings (H1/H2/H3)** and on bold prefixes in headline-style bullets (`**Term:** description`). Plain prose bullets keep sentence case.
  - **Zero em-dashes (—) and zero en-dashes (–)** in published content. Hyphen (-), parens, comma, or colon instead. Verbatim external quotes exempt.
  - **Garden pages no longer forced to hunt for blog cross-links** - removed that research step from the garden skill.
- Updated the five affected skills (`new-guided-blog-post`, `new-generated-blog-post`, `new-garden-page`, `non-tech-blog-editor`, `tech-blog-editor`) so drafting skills stop recommending em-dashes and editor skills flag every em/en-dash as a hard error but do NOT flag Title Case headings as an AI tell.

## Why

I know Title Case headings and em-dashes are AI tells - but I prefer Title Case aesthetically and want em-dashes banned outright because they've become too associated with AI slop to use comfortably. The AI-writing-tells file kept instructing Claude to do the opposite of what I want (L123 said "use sentence case instead", and two skills told Claude to "use em-dashes for personality"). The overrides are now canonical in two places with the reasoning captured, so future edits won't silently revert them.

## Test plan

- [ ] Grep `.claude/context/` and `.claude/skills/` for `em.dash|en.dash` - every remaining hit should sit inside an override/ban context (verified clean pre-commit).
- [ ] Grep for `sentence case|title case` - every hit should be in a Personal Override context.
- [ ] Dry-run an editor skill against a synthetic post containing a Title Case heading, a `**Term:**` bullet, em-dashes, and a sentence-case heading; expect flags only on the dashes and the sentence-case heading.
- [ ] Run `new-garden-page` skill end-to-end on a small idea; confirm Step 2 research no longer instructs a blog-cross-link search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized heading rules: Title Case required for H1–H3 and for bold “Term:” bullet prefixes; these are personal style overrides and won’t be flagged.
  * Prohibited em-dashes/en-dashes in prose; require hyphens, parentheses, commas, or colons for replacements, and mandate hyphens for numeric ranges; verbatim external quotes and code are exempt.
  * Updated all writing-checklists and voice guidance across skills to reflect these heading and dash conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->