### PR TITLE
feat(garden): add tech-bloggers page

### DIFF
--- a/content/garden/links/tech-bloggers/index.md
+++ b/content/garden/links/tech-bloggers/index.md
@@ -1,0 +1,21 @@
+---
+title: "Tech Bloggers I Enjoy Reading"
+date: 2026-04-15T00:00:00+00:00
+description: "A running list of tech bloggers whose writing I actively look forward to."
+garden_topic: "Links"
+status: "Seedling"
+---
+
+There's a lot of tech writing out there, and most of it is noise. This is a small, opinionated list of people whose posts I'll drop everything to read. I'll keep adding to it as I remember more.
+
+## [Vicki Boykis](https://vickiboykis.com/)
+
+An ML engineer who writes about machine learning, embeddings, and the weird shape of working in tech. Her [What are embeddings?](https://vickiboykis.com/what_are_embeddings/) essay is the thing I send people when they ask me what embeddings actually are. She also writes really honestly about industry trends without the hype.
+
+## [Mario Zechner](https://mariozechner.at)
+
+Creator of [libGDX](https://libgdx.com/) and a prolific tinkerer. Writes about game dev, low-level programming, and more recently a lot of interesting stuff on LLMs and tool-building. I like that he shows the workings — posts feel like watching someone think out loud.
+
+## [Gergely Orosz — The Pragmatic Engineer](https://pragmaticengineer.com)
+
+Former Uber engineer turned full-time writer. The Pragmatic Engineer is basically required reading if you want to know what's actually going on inside big tech companies — layoffs, comp, engineering culture, incidents. Gergely does the reporting that tech media mostly doesn't bother with any more.

--- a/content/garden/links/tech-bloggers/index.md
+++ b/content/garden/links/tech-bloggers/index.md
@@ -6,16 +6,20 @@ garden_topic: "Links"
 status: "Seedling"
 ---
 
-There's a lot of tech writing out there, and most of it is noise. This is a small, opinionated list of people whose posts I'll drop everything to read. I'll keep adding to it as I remember more.
+I love reading and learning, and there's a lot of tech writing out there. But, especially with the rise of AI, most of it is noise and trending to slop. 
+
+But there's some great writers out there fighting the good fight, and I thought I'd keep a running list of them here. 
+
+So, here is a opinionated list of people whose posts I seek out. Generally I'm just looking for people with a clear voice, who are realistic about recent tech trends, and don't veer too much into doomer vs booster on GenAI and the direction of travel coding is taking. 
 
 ## [Vicki Boykis](https://vickiboykis.com/)
 
-An ML engineer who writes about machine learning, embeddings, and the weird shape of working in tech. Her [What are embeddings?](https://vickiboykis.com/what_are_embeddings/) essay is the thing I send people when they ask me what embeddings actually are. She also writes really honestly about industry trends without the hype.
+An ML engineer who writes about machine learning, embeddings, and working in tech. I've been subscribed to her for a while but I really liked her recent post on [Mechanical Sympathy](https://vickiboykis.com/2026/04/13/mechanical-sympathy/) and it's one of the bloggers that inspired me to write this list in the first place. 
 
 ## [Mario Zechner](https://mariozechner.at)
 
-Creator of [libGDX](https://libgdx.com/) and a prolific tinkerer. Writes about game dev, low-level programming, and more recently a lot of interesting stuff on LLMs and tool-building. I like that he shows the workings — posts feel like watching someone think out loud.
+Creator of [pi](https://pi.dev/), an agent that isn't _quite_ for me but I enjoyed using and the philosphy behind it. 
 
 ## [Gergely Orosz — The Pragmatic Engineer](https://pragmaticengineer.com)
 
-Former Uber engineer turned full-time writer. The Pragmatic Engineer is basically required reading if you want to know what's actually going on inside big tech companies — layoffs, comp, engineering culture, incidents. Gergely does the reporting that tech media mostly doesn't bother with any more.
+Gergely is a former Uber engineer turned full-time writer. I like how that he gets a lot of good interviews where asks he asks well thought-out grounded questions. Honestly, it's a good balance of grounded but still wide-scoped tech reporting that feels like it's largely died off on bigger sites.

--- a/content/garden/links/tech-bloggers/index.md
+++ b/content/garden/links/tech-bloggers/index.md
@@ -10,16 +10,16 @@ I love reading and learning, and there's a lot of tech writing out there. But, e
 
 But there's some great writers out there fighting the good fight, and I thought I'd keep a running list of them here. 
 
-So, here is a opinionated list of people whose posts I seek out. Generally I'm just looking for people with a clear voice, who are realistic about recent tech trends, and don't veer too much into doomer vs booster on GenAI and the direction of travel coding is taking. 
+So, here is an opinionated list of people whose posts I seek out. Generally I'm just looking for people with a clear voice, who are realistic about recent tech trends, and don't veer too much into doomer vs booster on GenAI and the direction of travel coding is taking. 
 
 ## [Vicki Boykis](https://vickiboykis.com/)
 
-An ML engineer who writes about machine learning, embeddings, and working in tech. I've been subscribed to her for a while but I really liked her recent post on [Mechanical Sympathy](https://vickiboykis.com/2026/04/13/mechanical-sympathy/) and it's one of the bloggers that inspired me to write this list in the first place. 
+An ML engineer who writes about machine learning, embeddings, and working in tech. I've been subscribed to her for a while but I really liked her recent post on [Mechanical Sympathy](https://vickiboykis.com/2026/04/13/mechanical-sympathy/) and she's one of the bloggers who inspired me to write this list in the first place. 
 
 ## [Mario Zechner](https://mariozechner.at)
 
-Creator of [pi](https://pi.dev/), an agent that isn't _quite_ for me but I enjoyed using and the philosphy behind it. 
+Creator of [pi](https://pi.dev/), an agent that isn't _quite_ for me but I enjoyed using and the philosophy behind it. 
 
 ## [Gergely Orosz — The Pragmatic Engineer](https://pragmaticengineer.com)
 
-Gergely is a former Uber engineer turned full-time writer. I like how that he gets a lot of good interviews where asks he asks well thought-out grounded questions. Honestly, it's a good balance of grounded but still wide-scoped tech reporting that feels like it's largely died off on bigger sites.
+Gergely is a former Uber engineer turned full-time writer. I like how he gets a lot of good interviews where he asks well-thought-out, grounded questions. Honestly, it's a good balance of grounded but still wide-scoped tech reporting that feels like it's largely died off on bigger sites.


### PR DESCRIPTION
## Summary
- Adds a new digital garden page listing favourite tech bloggers
- Includes entries for Vicki Boykis, Mario Zechner, and Gergely Orosz with personal takes on why they're worth reading

## Test plan
- [ ] Verify page renders correctly with `hugo server`
- [ ] Check all external links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a curated collection of recommended tech bloggers with detailed descriptions of their focus areas and contributions to the tech community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->