### PR TITLE
Update YouTube video reference in Ma concept article

### DIFF
--- a/content/garden/concepts/ma/index.md
+++ b/content/garden/concepts/ma/index.md
@@ -10,7 +10,7 @@ Ma (間) is a Japanese concept that roughly translates to "the space between thi
 
 Way back in the day, when I was doing A-Level Film Studies was the first time I'd heard it, and that original memory was re-sparked for me recently watching this YouTube short of Brennan Lee Mulligan and Matt Mercer (of Critical Role fame for ya'll non-nerds out there) talking about Ma in the context of *Seven Samurai* and Kurosawa:
 
-{{< youtube jTh8CaB0Ugk >}}
+{{< youtube id="jTh8CaB0Ugk" title="Brennan Lee Mulligan and Matt Mercer discuss the concept of Ma in Seven Samurai" >}}
 
 Now I wish I could be cool enough to say my first experience with Ma was with a Kurosawa picture, but it was actually with Miyazaki of Ghibli fame. I think Spirited Away (2003 western release)? Because that lines up with his interview with Roger Ebert when he talked about Ma in 2002 so I imagine that might have been one of the sources we'd referenced in class:
 

--- a/content/garden/concepts/ma/index.md
+++ b/content/garden/concepts/ma/index.md
@@ -10,7 +10,7 @@ Ma (間) is a Japanese concept that roughly translates to "the space between thi
 
 Way back in the day, when I was doing A-Level Film Studies was the first time I'd heard it, and that original memory was re-sparked for me recently watching this YouTube short of Brennan Lee Mulligan and Matt Mercer (of Critical Role fame for ya'll non-nerds out there) talking about Ma in the context of *Seven Samurai* and Kurosawa:
 
-{{< youtube tDS2olk8Jx0 >}}
+{{< youtube jTh8CaB0Ugk >}}
 
 Now I wish I could be cool enough to say my first experience with Ma was with a Kurosawa picture, but it was actually with Miyazaki of Ghibli fame. I think Spirited Away (2003 western release)? Because that lines up with his interview with Roger Ebert when he talked about Ma in 2002 so I imagine that might have been one of the sources we'd referenced in class:
 


### PR DESCRIPTION
## Summary
Updated the embedded YouTube video in the Ma concept article to reference a different video discussing the topic.

## Changes
- Replaced YouTube video ID `tDS2olk8Jx0` with `jTh8CaB0Ugk` in the Ma concept documentation
- The video still features Brennan Lee Mulligan and Matt Mercer discussing Ma in the context of *Seven Samurai* and Kurosawa's filmmaking

## Details
This change updates the embedded video resource while maintaining the same context and discussion topic about the Japanese concept of Ma (間) and its application in film.

https://claude.ai/code/session_01H3ut7pT6LMct4gKrpn4nf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated an embedded YouTube video in garden concepts content: replaced the referenced video and added explicit video id and title parameters for clearer embedding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->