### PR TITLE
Sort garden sections by title in list layout

### DIFF
--- a/layouts/garden/list.html
+++ b/layouts/garden/list.html
@@ -1,7 +1,7 @@
 {{- define "main" }}
 
 {{- $topicData := .Site.Data.garden.topics -}}
-{{- $sections := .Sections -}}
+{{- $sections := .Sections.ByTitle -}}
 
 <header class="page-header">
   {{- partial "breadcrumbs.html" . }}


### PR DESCRIPTION
## Summary
Updated the garden list layout to sort sections alphabetically by title for improved organization and consistency.

## Changes
- Modified `layouts/garden/list.html` to use `.Sections.ByTitle` instead of `.Sections`
- This ensures sections are displayed in alphabetical order by their title rather than in default order

## Implementation Details
The change leverages Hugo's built-in `.ByTitle` method to automatically sort the sections collection, providing a more predictable and user-friendly browsing experience in the garden list view.

https://claude.ai/code/session_01XsaFErsh3zcJ7noMQ8kCzb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Garden sections are now displayed in alphabetical order by title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->