### PR TITLE
Add Simon Willison and Mitchell Hashimoto to tech bloggers

### DIFF
--- a/content/garden/links/tech-bloggers/index.md
+++ b/content/garden/links/tech-bloggers/index.md
@@ -23,3 +23,11 @@ Creator of [pi](https://pi.dev/), an agent that isn't _quite_ for me but I enjoy
 ## [Gergely Orosz — The Pragmatic Engineer](https://pragmaticengineer.com)
 
 Gergely is a former Uber engineer turned full-time writer. I like how he gets a lot of good interviews where he asks well-thought-out, grounded questions. Honestly, it's a good balance of grounded but still wide-scoped tech reporting that feels like it's largely died off on bigger sites.
+
+## [Simon Willison](https://simonwillison.net/)
+
+Co-creator of Django and the person behind [Datasette](https://datasette.io/). His link blog is the best way I've found to keep up with what's actually happening in LLM-land without drowning in hype. He's prolific without being noisy, which is a rare combination, and his annotated posts about new model releases consistently teach me something I didn't know I needed to know.
+
+## [Mitchell Hashimoto](https://mitchellh.com/writing)
+
+Co-founder of HashiCorp (so, Terraform, Vagrant, Vault and friends) and these days working on the [Ghostty](https://ghostty.org/) terminal. His writing is less frequent but always worth the wait. His posts on software craft and tooling are a practical take from someone who has shipped a lot of software the hard way.


### PR DESCRIPTION
## Summary
Added two new tech bloggers to the curated list of technology content creators.

## Changes
- **Simon Willison**: Added entry highlighting his work as Django co-creator and creator of Datasette, with emphasis on his link blog as a valuable resource for staying current with LLM developments without hype
- **Mitchell Hashimoto**: Added entry noting his role as HashiCorp co-founder and current work on Ghostty terminal, emphasizing the practical value of his infrequent but high-quality writing on software craft and tooling

## Details
Both additions follow the existing format of the tech bloggers list, providing context about each person's background and explaining why their content is worth following.

https://claude.ai/code/session_01Lqt7BXRiizte9HSG8QaXzc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new recommended tech bloggers to the curated reading list, featuring experts specializing in Django, Datasette, practical LLM updates, and infrastructure tooling with a focus on crafted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->