### PR TITLE
feat(skills): add /new-garden-post alias skill for /new-garden-page

### DIFF
--- a/.claude/commands/new-garden-post.md
+++ b/.claude/commands/new-garden-post.md
@@ -1,0 +1,1 @@
+Alias for the new-garden-page skill. Invoke the `new-garden-page` skill now, passing any arguments from `$ARGUMENTS` as the initial idea.

--- a/.claude/commands/new-garden-post.md
+++ b/.claude/commands/new-garden-post.md
@@ -1,1 +1,0 @@
-Alias for the new-garden-page skill. Invoke the `new-garden-page` skill now, passing any arguments from `$ARGUMENTS` as the initial idea.

--- a/.claude/skills/new-garden-post/SKILL.md
+++ b/.claude/skills/new-garden-post/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: new-garden-post
+description: Alias for /new-garden-page. Creates a new digital garden page for petersouter.xyz.
+argument-hint: [your idea]
+disable-model-invocation: true
+---
+
+Invoke the `new-garden-page` skill now, passing `$ARGUMENTS` as the initial idea.

--- a/.claude/skills/new-garden-post/SKILL.md
+++ b/.claude/skills/new-garden-post/SKILL.md
@@ -5,4 +5,6 @@ argument-hint: [your idea]
 disable-model-invocation: true
 ---
 
+# Garden Post Alias
+
 Invoke the `new-garden-page` skill now, passing `$ARGUMENTS` as the initial idea.


### PR DESCRIPTION
## Summary

Adds `/new-garden-post` as an alias for the `/new-garden-page` skill so a typo-prone variant doesn't silently fail.

* Created `.claude/skills/new-garden-post/SKILL.md` (per current Claude Code docs, skills are recommended over the legacy `.claude/commands/` location).
* Frontmatter sets `description`, `argument-hint`, and `disable-model-invocation: true` so the slash menu shows clean text and Claude doesn't autonomously load the alias alongside the canonical skill.
* The skill body delegates to `new-garden-page`, forwarding `$ARGUMENTS` as the initial idea.

## Test plan

- [ ] `/new-garden-post some idea` triggers the `new-garden-page` skill with `some idea` as the initial idea.
- [ ] `/new-garden-post` (no args) still triggers the parent skill which then prompts for the idea.
- [ ] Slash menu shows the alias with the new `description`, not the legacy "Alias for…" body text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command alias `new-garden-post`. It acts as an entry point that forwards any provided arguments as the initial idea to the existing post workflow, simplifying how input is passed through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->